### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.1.0](https://github.com/cakevm/mev-builders/releases/tag/v0.1.0) - 2025-06-09
-
-### Added
-
-- Update builders every week
-
-### Other
-
-- Add release-plz
-- weekly builder order update ([#7](https://github.com/cakevm/mev-builders/pull/7))
-- Print missed builders
-- add missing id
-- Include gen code
-- Add more details
-- weekly builder order update ([#4](https://github.com/cakevm/mev-builders/pull/4))
-- correct file path
-- Clean up temp files
-- Fix missing others
-- fmt
-- Use identifier
-- Add examples
-- Initial commit
+- Initial release


### PR DESCRIPTION



## 🤖 New release

* `mev-builders`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/cakevm/mev-builders/releases/tag/v0.1.0) - 2025-06-09

### Added

- Update builders every week

### Other

- Add release-plz
- weekly builder order update ([#7](https://github.com/cakevm/mev-builders/pull/7))
- Print missed builders
- add missing id
- Include gen code
- Add more details
- weekly builder order update ([#4](https://github.com/cakevm/mev-builders/pull/4))
- correct file path
- Clean up temp files
- Fix missing others
- fmt
- Use identifier
- Add examples
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).