### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/cakevm/mev-builders/compare/v0.1.0...v0.1.1) - 2025-06-09
+
+### Other
+
+- release v0.1.0 ([#8](https://github.com/cakevm/mev-builders/pull/8))
+
 ## [0.1.0](https://github.com/cakevm/mev-builders/releases/tag/v0.1.0) - 2025-06-09
 - Initial release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "mev-builders"
-version = "0.1.0"
+version = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mev-builders"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MEV builder endpoints, all in one place"


### PR DESCRIPTION



## 🤖 New release

* `mev-builders`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/cakevm/mev-builders/compare/v0.1.0...v0.1.1) - 2025-06-09

### Other

- release v0.1.0 ([#8](https://github.com/cakevm/mev-builders/pull/8))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).